### PR TITLE
Add Markdown command output caption option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,3 +18,17 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 ### Changed
 
 - `getterm.bat` の実行方法を `.exe` に変更し、コンソールウィンドウが表示されないように改善
+
+## [1.2.0] - 2025-03-15
+
+### Added
+
+- Markdownエクスポートでコマンド実行結果のキャプションに **Command Output:** を追加
+
+### Changed
+
+- `getterm.bat` の実行方法を `.exe` に変更し、コンソールウィンドウが表示されないように改善
+
+### Fixed
+
+- sudo vi エディタ編集モードで、権限不足でキャプチャーに失敗する問題修正。キャプチャー実行時に sudo cat コマンドを追加

--- a/src/exporter/ExportDialog.ts
+++ b/src/exporter/ExportDialog.ts
@@ -61,6 +61,7 @@ export class ExportDialog {
                                 includeCommandInfo: message.data.includeCommandInfo,
                                 trimLineCount: parseInt(message.data.trimLineCount, 10),
                                 openMarkdown: message.data.openMarkdown,
+                                captionCommandOutput: message.data.captionCommandOutput,
                                 exportPath: uri,
                             };
                             resolve(result);
@@ -113,6 +114,10 @@ export class ExportDialog {
             <input type="checkbox" id="includeCommandInfo" />
             Include Command Metadata (Elapsed Time, Exit Code, etc.)
         </label>
+        <label>
+            <input type="checkbox" id="captionCommandOutput" checked />
+            Caption Command Output (Markdown only)
+        </label>
         <label>Output Settings:</label>
         <label>Lines to keep (Start/End):
             <input id="trimLineCount" type="number" value="5" min="1" />
@@ -133,6 +138,7 @@ export class ExportDialog {
                 includeCommandInfo: document.getElementById("includeCommandInfo").checked,
                 trimLineCount: document.getElementById("trimLineCount").value,
                 openMarkdown: document.getElementById("openMarkdown").checked,
+                captionCommandOutput: document.getElementById("captionCommandOutput").checked,
             };
             vscode.postMessage({ command: "selectSaveLocation", data });
         });

--- a/src/exporter/MarkdownExport.ts
+++ b/src/exporter/MarkdownExport.ts
@@ -11,6 +11,7 @@ export interface ExportParameters {
     trimLineCount: number;
     openMarkdown: boolean;
     exportPath: vscode.Uri;
+    captionCommandOutput : boolean;
 }
 
 export class MarkdownExport {
@@ -121,7 +122,8 @@ export class MarkdownExport {
     
         // Optionally include command output
         if (params.includeOutput) {
-            this.addCommandOutput(lines, command, params.trimLineCount);
+            // this.addCommandOutput(lines, command, params.trimLineCount);
+            this.addCommandOutput(lines, command, params);
         }
     }
 
@@ -135,12 +137,18 @@ export class MarkdownExport {
         lines.push(`# Exit Code: ${command.exit_code}`);
     }
     
-    private static addCommandOutput(lines: string[], command: CommandRow, trimLineCount: number): void {
+    // private static processMarkdownCell(lines: string[], text: string, params: ExportParameters): void {
+    private static addCommandOutput(lines: string[], command: CommandRow, params: ExportParameters): void {
+        const trimLineCount = params.trimLineCount ?? 5;
+        // const captionCommandOutput = params.captionCommandOutput ?? false;
         let outputText = this.getOutputText(command.output, trimLineCount);
     
         if (outputText) {
             if (command.file_operation_mode === 'downloaded') {
                 outputText = this.getDownloadContent(outputText);
+            }
+            if (params.captionCommandOutput) {
+                lines.push(`**Command Output:**`);
             }
             lines.push("```text");
             lines.push(outputText, "```", "");

--- a/src/test/suite/MarkdownExport.test.ts
+++ b/src/test/suite/MarkdownExport.test.ts
@@ -77,6 +77,7 @@ suite("MarkdownExport.convertNotebookToMarkdown", () => {
             trimLineCount: 2,
             exportPath: vscode.Uri.file("/mock/path/output.md"),
             openMarkdown: false,
+            captionCommandOutput: false,
         };
 
         // Run the method
@@ -118,7 +119,10 @@ Command output line 3
             openMarkdown: false,
         };
 
-        const result = await MarkdownExport.convertNotebookToMarkdown(mockNotebook1, params);
+        const result = await MarkdownExport.convertNotebookToMarkdown(mockNotebook1, {
+            ...params,
+            captionCommandOutput: false,
+        });
         const expectedOutput = `
 ### Markdown Header
 Markdown content
@@ -146,6 +150,7 @@ Command output line 3
             trimLineCount: 2,
             exportPath: vscode.Uri.file("/mock/path/output.md"),
             openMarkdown: false,
+            captionCommandOutput: false,
         };
 
         const result = await MarkdownExport.convertNotebookToMarkdown(mockNotebook1, params);
@@ -169,6 +174,7 @@ echo 'Hello, World!'
             trimLineCount: 1,
             exportPath: vscode.Uri.file("/mock/path/output.md"),
             openMarkdown: false,
+            captionCommandOutput: false,
         };
 
         const result = await MarkdownExport.convertNotebookToMarkdown(mockNotebook1, params);
@@ -198,6 +204,7 @@ Command output line 3
             trimLineCount: 0,
             exportPath: vscode.Uri.file("/mock/path/output.md"),
             openMarkdown: false,
+            captionCommandOutput: false,
         };
 
         const result = await MarkdownExport.convertNotebookToMarkdown(mockNotebook2, params);
@@ -224,6 +231,7 @@ ls -l
             trimLineCount: 0,
             exportPath: vscode.Uri.file("/mock/path/output.md"),
             openMarkdown: false,
+            captionCommandOutput: false,
         };
 
         const result = await MarkdownExport.convertNotebookToMarkdown(mockNotebook2, params);


### PR DESCRIPTION
This PR adds support for captions like 'Command Output:' or 'Execution Result:' to Markdown code blocks.