### PR TITLE
Set includeCommandInfo checkbox default based on export type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ### Changed
 
-- `getterm.bat` の実行方法を `.exe` に変更し、コンソールウィンドウが表示されないように改善
+- Excelエクスポートの実行時間、終了コード出力オプションの規定値を有効化に変更
 
 ### Fixed
 

--- a/src/exporter/ExportDialog.ts
+++ b/src/exporter/ExportDialog.ts
@@ -58,7 +58,7 @@ export class ExportDialog {
                             const result: ExportParameters = {
                                 includeMetadata: message.data.includeMetadata,
                                 includeOutput: message.data.includeOutput,
-                                includeCommandInfo: message.data.includeCommandInfo,
+                                includeCommandInfo: this.exportType.extension === "xlsx" ? true : message.data.includeCommandInfo,
                                 trimLineCount: parseInt(message.data.trimLineCount, 10),
                                 openMarkdown: message.data.openMarkdown,
                                 captionCommandOutput: message.data.captionCommandOutput,
@@ -111,7 +111,8 @@ export class ExportDialog {
             Export Command Outputs(Default)
         </label>
         <label>
-            <input type="checkbox" id="includeCommandInfo" />
+            <input type="checkbox" id="includeCommandInfo" 
+            ${this.exportType.extension === "xlsx" ? "checked" : ""} />
             Include Command Metadata (Elapsed Time, Exit Code, etc.)
         </label>
         <label>


### PR DESCRIPTION
This PR updates the ExportDialog to set the includeCommandInfo checkbox default to true for Excel and false for Markdown exports.