### PR TITLE
Fix permission error when capturing admin file with base64

### DIFF
--- a/src/ConsernedFileDownloader.ts
+++ b/src/ConsernedFileDownloader.ts
@@ -153,9 +153,13 @@ export class ConsernedFileDownloader {
         TerminalSessionManager.disableShellIntegrationEvent(this.terminal); // Disable shell events
 
         // OSC 633 ; P ; <Property>=<Value> ST - Set a property on the terminal, only known properties will be handled.
-        const captureCommand = `echo -e "\\e]633;P;base64=$(cat ${this.commandAccessFile} | base64)\\a"`;
+        // const captureCommand = `echo -e "\\e]633;P;base64=$(cat ${this.commandAccessFile} | base64)\\a"`;
         // const commandText = `${this.sudoCommand ? this.sudoCommand + " " : ""}cat ${this.commandAccessFile}`;
-        const commandText = `${this.sudoCommand ? this.sudoCommand + " " : ""}${captureCommand}`;
+        // const commandText = `${this.sudoCommand ? this.sudoCommand + " " : ""}${captureCommand}`;
+        const sudoCommandd = this.sudoCommand ? this.sudoCommand + " " : "";
+        const commandText = `echo -e "\\e]633;P;base64=$(${sudoCommandd} cat ${this.commandAccessFile} | base64)\\a"`;
+       
+       
         this.terminal.sendText(commandText); // Send 'cat' command to terminal
         this.mode = DownloaderMode.Save;
         return this;


### PR DESCRIPTION
This PR updates the command used to capture and base64-encode administrator config file by replacing \cat\ with \sudo cat\, to avoid permission denied errors when the file is edited via sudo (e.g., sudo vi).